### PR TITLE
fix angle difference calculation (close to pi/2 and -pi/2) for iou re…

### DIFF
--- a/utils/dataset_processing/grasp.py
+++ b/utils/dataset_processing/grasp.py
@@ -266,7 +266,7 @@ class GraspRectangle:
         :param angle_threshold: Maximum angle difference between GraspRectangles
         :return: IoU between Grasp Rectangles
         """
-        if abs(self.angle - gr.angle) % np.pi > angle_threshold:
+        if abs((self.angle - gr.angle + np.pi/2) % np.pi - np.pi/2) > angle_threshold:
             return 0
 
         rr1, cc1 = self.polygon_coords()


### PR DESCRIPTION
Hello Doug, 
first of all thank you for your amazing work.

I think there's a hiccup in the IoU calculation for grasps.
Your implementation currently returns 0.0 IoU when comparing grasps with groudtruth_angles close to pi/2 or -pi/2 if the estimated_grasp_angle is close to -pi/2 or pi/2 respectively.
If I'm not mistaken those estimated grasps should be accepted since they are essentially encoding the same (just mirrored) grasp configuration.

e.g.:
```
ground_truth_angle = 1.57                                                                                                                         
estimated_angle = -1.57                                                                                                                           

abs(ground_truth_angle - estimated_angle) % np.pi                                                                                                 
3.14

abs((ground_truth_angle - estimated_angle + np.pi/2) % np.pi - np.pi/2)                                                                           
0.0015926535897925476
```

hth :-)
I hope you, continue your great efforts